### PR TITLE
Add support for parsing ranges

### DIFF
--- a/OptionParser.h
+++ b/OptionParser.h
@@ -156,6 +156,52 @@ public:
   }
 
   template<typename T>
+  std::vector<T> parseRange(const std::string& input) const
+  {
+    std::vector<T> result;
+
+    // Check if input contains "..." indicating a range
+    if (input.find("...") != std::string::npos)
+    {
+      // Parse the start and end of the range
+      size_t pos = input.find("...");
+      T start = static_cast<T>(std::stod(input.substr(0, pos)));
+      T end = static_cast<T>(std::stod(input.substr(pos + 3)));
+
+      // Generate all numbers in the range [start, end]
+      for (T i = start; i <= end; ++i)
+        result.push_back(i);
+    }
+    else // Treat as comma delimited list
+    {
+      std::stringstream ss(input);
+      std::string item;
+
+      // Split by comma and add each number to the vector
+      while (std::getline(ss, item, ','))
+        result.push_back(static_cast<T>(std::stod(item)));
+    }
+
+    return result;
+  }
+
+  template<typename T>
+  bool getOptionalRange(const std::string& name, std::vector<T>& vec) const
+  {
+    std::string valueString;
+
+    // Retrieve the option's value as a string
+    if (!getOptionValueString(name, &valueString))
+      return false;
+
+    // Parse the string as a range
+    vec.clear();
+    vec = parseRange<T>(valueString);
+
+    return true;
+  }
+
+  template<typename T>
   bool getRequiredValue(const std::string &name, T *value) const
   {
     if(!isSet(name))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OptionParser
 
-OptionParser is a `getopt_long()` wrapper library for parsing command-line 
+OptionParser is a `getopt_long()` wrapper library for parsing command-line
 options in C++ for Unix-like platforms.
 
 ## Getting Started
@@ -37,18 +37,15 @@ See `example.cpp` below.  It produces formatted output for help:
 usage: example [options] output
 
 Options:
-  -h, --help            Display help message.                                   
-  -i, --input <file>    Path for input.                                         
-  -r, --radius <float>  Search radius. (Default: 1.0)                           
-  -x, --exclude <bool>  Prune outliers. (Default: false)                        
-  -s, --skip            Skip pre-processing.     
+  -h, --help            Display help message.
+  -i, --input <file>    Path for input.
+  -r, --radius <float>  Search radius. (Default: 1.0)
+  -x, --exclude <bool>  Prune outliers. (Default: false)
+  -s, --skip            Skip pre-processing.
+  -v, --vector <range>  Add a range to a vector.
 ```
 
 ```c++
-#include <OptionParser.h>
-#include <iostream>
-#include <string>
-
 int main(int argc, char *argv[])
 {
   // Initialize with program name that will be shown in the help
@@ -74,6 +71,12 @@ int main(int argc, char *argv[])
   // Command line option with no values
   parser.addOption('s', "skip", "Skip pre-processing.");
 
+  // Command line option that accepts -v, --vector for a range of values
+  // Values can be comma delimited or an inclusive range with an ellipsis,
+  // e.g. 1,2,3,4,5 is the same as 1...5
+  // The inclusive range is incremented by 1
+  parser.addOption('v', "vector", "Add a range to a vector.", "range");
+
   // Adds this value as a positional argument in the help
   parser.addPositionalArgument("output");
 
@@ -87,6 +90,10 @@ int main(int argc, char *argv[])
   // Get optional parameters
   parser.getOptionalValue("exclude", &exclude);
   parser.getOptionalValue("radius", &radius);
+
+  // Get optional range
+  std::vector<int> vec;
+  parser.getOptionalRange("vector", vec);
 
   // Test if option has been specified on the command line
   if(parser.isSet("skip"))
@@ -104,7 +111,7 @@ int main(int argc, char *argv[])
     output = positional.at(0);
   } else
   {
-    std::cerr << "Exactly on positional argument required for output.\n"
+    std::cerr << "Exactly one positional argument required for output.\n"
               << parser.helpString();
   }
 
@@ -113,9 +120,13 @@ int main(int argc, char *argv[])
   std::cout << "input:  " << input << '\n';
   std::cout << "exclude: " << exclude << '\n';
   std::cout << "output:  " << output << '\n';
+  std::cout << "vector: ";
+  for(auto v : vec)
+    std::cout << v << ' ';
+  std::cout << '\n';
 
   return 0;
 }
 ```
 
-Copyright 2022-2023, Joshua Fraser  
+Copyright 2022-2023, Joshua Fraser

--- a/example.cpp
+++ b/example.cpp
@@ -1,6 +1,7 @@
 #include <OptionParser.h>
 #include <iostream>
 #include <string>
+#include <vector>
 
 int main(int argc, char *argv[])
 {
@@ -27,6 +28,12 @@ int main(int argc, char *argv[])
   // Command line option with no values
   parser.addOption('s', "skip", "Skip pre-processing.");
 
+  // Command line option that accepts -v, --vector for a range of values
+  // Values can be comma delimited or an inclusive range with an ellipsis,
+  // e.g. 1,2,3,4,5 is the same as 1...5
+  // The inclusive range is incremented by 1
+  parser.addOption('v', "vector", "Add a range to a vector.", "range");
+
   // Adds this value as a positional argument in the help
   parser.addPositionalArgument("output");
 
@@ -40,6 +47,10 @@ int main(int argc, char *argv[])
   // Get optional parameters
   parser.getOptionalValue("exclude", &exclude);
   parser.getOptionalValue("radius", &radius);
+
+  // Get optional range
+  std::vector<int> vec;
+  parser.getOptionalRange("vector", vec);
 
   // Test if option has been specified on the command line
   if(parser.isSet("skip"))
@@ -66,6 +77,10 @@ int main(int argc, char *argv[])
   std::cout << "input:  " << input << '\n';
   std::cout << "exclude: " << exclude << '\n';
   std::cout << "output:  " << output << '\n';
+  std::cout << "vector: ";
+  for(auto v : vec)
+    std::cout << v << ' ';
+  std::cout << '\n';
 
   return 0;
 }

--- a/example.cpp
+++ b/example.cpp
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
     output = positional.at(0);
   } else
   {
-    std::cerr << "Exactly on positional argument required for output.\n"
+    std::cerr << "Exactly one positional argument required for output.\n"
               << parser.helpString();
   }
 


### PR DESCRIPTION
Changed 'on' to 'one' in main.

Added range parsing for vectors, which will take a string with numbers in two different formats.
A comma delimited string of numbers will read just those numbers.
A string of two numbers separated by an ellipsis will read the first number and then increment by one to get to the last number, and then add the last number.

This can be useful for code that may test a range of variables.

